### PR TITLE
docs: 降低設計師初學者的學習門檻

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         什麼是 Git？
       </h1>
       <p class="chapter__subtitle reveal reveal-delay-1">
-        讓創意工作者「看懂」版本控制的心智模型
+        讓你不再需要「檔案_v3_final_真的final」
       </p>
       <div class="divider reveal reveal-delay-2"></div>
       <div class="chapter__body">
@@ -20,7 +20,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           Git 不是程式設計師的專屬工具。<br />
           它是<strong>創作流程</strong>的核心——無論你是平面設計師、字型設計師，還是藝術家。
         </p>
-        <p class="scroll-hint reveal reveal-delay-4">
+        <p class="reveal reveal-delay-4">
+          本教學會展示指令，讓你了解「背後發生什麼事」——<br />
+          但日常使用，<strong>圖形化工具</strong>一樣好用。
+        </p>
+        <p class="scroll-hint reveal reveal-delay-5">
           <span class="scroll-hint__text">向下捲動，開始探索</span>
           <i class="ph ph-caret-down scroll-hint__arrow" aria-hidden="true"></i>
         </p>
@@ -103,11 +107,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </button>
         </div>
 
-        <!-- Conventional Commits 說明 -->
-        <div class="inline-callout reveal reveal-delay-4">
-          <i class="ph-fill ph-lightbulb inline-callout__icon"></i>
-          <div>
-            <p>常見的提交前綴：</p>
+        <!-- Conventional Commits 說明（可折疊） -->
+        <details class="inline-callout inline-callout--collapsible reveal reveal-delay-4">
+          <summary>
+            <i class="ph-fill ph-lightbulb inline-callout__icon"></i>
+            <span>進階：約定式提交格式</span>
+          </summary>
+          <div class="inline-callout__content">
+            <p>團隊協作時，統一的提交格式讓歷史更易讀。<br />一開始只要寫清楚改了什麼就好：</p>
             <ul class="commit-types">
               <li><code>feat:</code> 新功能</li>
               <li><code>fix:</code> 修正錯誤</li>
@@ -115,7 +122,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               <li><code>refactor:</code> 重構</li>
             </ul>
           </div>
-        </div>
+        </details>
 
         <!-- 範例 -->
         <div class="inline-callout reveal reveal-delay-5">
@@ -141,8 +148,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </h2>
       <div class="chapter__body">
         <p class="reveal reveal-delay-2">
-          把本地的 commit 上傳到遠端伺服器，<br />
-          就像同步到雲端硬碟——備份，也方便協作。
+          把本地的 commit 推送到雲端——<br />
+          就像把 Figma 存到雲端，讓你在別台電腦也能開。
         </p>
 
         <!-- CLI 區塊 -->
@@ -191,8 +198,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </h2>
       <div class="chapter__body">
         <p class="reveal reveal-delay-2">
-          建立分支，在獨立的空間嘗試新想法，<br />
-          不會影響主線的穩定版本。
+          建立分支，就像「另存新檔」試新配色——<br />
+          但 Git 記得它們的關係，隨時可以合併回來。
         </p>
 
         <!-- CLI 區塊 -->
@@ -231,8 +238,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </h2>
       <div class="chapter__body">
         <p class="reveal reveal-delay-2">
-          用 issue 記錄待辦事項、回報問題、<br />
-          或討論新功能。
+          <strong>Git</strong> 是版本控制工具，<strong>GitHub</strong> 是存放專案的平台。<br />
+          Issue 是 GitHub 提供的專案管理功能——<br />
+          就像 Notion 的待辦事項，但跟你的檔案直接連結。
         </p>
 
         <!-- 內嵌概念卡片（小螢幕顯示，大螢幕由星座標籤取代） -->
@@ -270,12 +278,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <h2 class="chapter__title reveal-title">
         <i class="ph ph-git-pull-request chapter__icon"></i>
         <span class="chapter__title-en">pull request</span>
-        <span class="chapter__title-zh">拉取請求</span>
+        <span class="chapter__title-zh">拉取請求（PR）</span>
       </h2>
       <div class="chapter__body">
         <p class="reveal reveal-delay-2">
-          分支完成後，發起 pull request 請求合併，<br />
-          讓自己或團隊成員審查變更。
+          分支完成後，發起 Pull Request（簡稱 PR）請求合併。<br />
+          「Pull」的意思是：你「請求」對方把你的分支「拉」進主線。
         </p>
 
         <!-- 內嵌概念卡片（小螢幕顯示，大螢幕由星座標籤取代） -->
@@ -367,7 +375,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </h2>
       <div class="chapter__body">
         <p class="reveal reveal-delay-1">
-          你已經建立了 Git 的<strong>心智模型</strong>。<br />
+          你已經掌握了 Git 的<strong>核心概念</strong>。<br />
           現在，試著用它吧。
         </p>
         <div class="divider reveal reveal-delay-2"></div>
@@ -390,6 +398,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <span>— 免費的進階圖形介面</span>
           </li>
         </ul>
+
+        <!-- 5 分鐘快速開始 -->
+        <div class="divider reveal reveal-delay-5"></div>
+        <div class="quick-start reveal reveal-delay-6">
+          <h3>5 分鐘開始</h3>
+          <ol class="quick-start__steps">
+            <li>下載 <a href="https://desktop.github.com/" target="_blank" rel="noopener">GitHub Desktop</a></li>
+            <li>建立一個資料夾，放入你的設計檔</li>
+            <li>在 GitHub Desktop 點「Add」→「Create New Repository」</li>
+            <li>恭喜！你已經在使用 Git 了 🎉</li>
+          </ol>
+        </div>
       </div>
     </div>
   </section>

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -520,6 +520,53 @@ code {
   margin-right: var(--space-xs);
 }
 
+/* 可折疊 callout（details/summary） */
+.inline-callout--collapsible {
+  cursor: pointer;
+}
+
+.inline-callout--collapsible summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  list-style: none;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.inline-callout--collapsible summary::-webkit-details-marker {
+  display: none;
+}
+
+.inline-callout--collapsible summary::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--star-cyan);
+  margin-left: auto;
+  transition: transform var(--duration-fast) ease-out;
+}
+
+.inline-callout--collapsible[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.inline-callout--collapsible .inline-callout__icon {
+  margin-bottom: 0;
+}
+
+.inline-callout__content {
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--border);
+}
+
+.inline-callout__content p {
+  margin-bottom: var(--space-sm);
+}
+
 /* ── 7. 星座畫布 ── */
 .constellation-canvas {
   position: fixed;
@@ -767,6 +814,7 @@ code {
 .reveal-delay-3 { transition-delay: 300ms; }
 .reveal-delay-4 { transition-delay: 400ms; }
 .reveal-delay-5 { transition-delay: 500ms; }
+.reveal-delay-6 { transition-delay: 600ms; }
 
 /* 標題動畫 */
 .reveal-title {
@@ -852,6 +900,66 @@ code {
 .tools-list span {
   color: var(--text-ghost);
   font-size: 0.9rem;
+}
+
+/* ── 13. 快速開始區塊 ── */
+.quick-start {
+  margin-top: var(--space-lg);
+}
+
+.quick-start h3 {
+  margin-bottom: var(--space-md);
+}
+
+.quick-start__steps {
+  list-style: none;
+  counter-reset: step;
+}
+
+.quick-start__steps li {
+  position: relative;
+  padding-left: calc(var(--space-lg) + var(--space-sm));
+  padding-bottom: var(--space-md);
+  border-left: 2px solid var(--border);
+  margin-left: 12px;
+  counter-increment: step;
+}
+
+.quick-start__steps li:last-child {
+  border-left-color: transparent;
+  padding-bottom: 0;
+}
+
+.quick-start__steps li::before {
+  content: counter(step);
+  position: absolute;
+  left: -13px;
+  top: 0;
+  width: 24px;
+  height: 24px;
+  background: var(--star-cyan);
+  color: var(--ink-black);
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-start__steps li:last-child::before {
+  background: var(--star-gold);
+}
+
+.quick-start__steps a {
+  color: var(--star-cyan);
+  text-decoration: none;
+  transition: color var(--duration-fast) ease-out;
+}
+
+.quick-start__steps a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 /* ── 10. 特殊效果 ── */


### PR DESCRIPTION
## Summary

根據「設計師初學者」視角的 UX 評估，優化教學網站內容，使非技術背景的創意工作者更容易理解 Git 概念。

### 變更內容

- **序章**：加入「圖形化工具」說明，降低 CLI 恐懼
- **比喻重寫**：用 Figma、另存新檔等設計師熟悉的比喻
- **第五章**：明確區分 Git 與 GitHub
- **結語**：加入「5 分鐘快速開始」行動指引
- **第二章**：Conventional Commits 改為可折疊區塊
- **第六章**：Pull Request 術語加入完整說明

## Related Issues

Closes #2, #3, #4, #5, #6, #7

Parent Epic: #1

## Test plan

- [x] `npm run build` 成功
- [ ] 檢視序章是否提到圖形化工具
- [ ] 檢視各章節比喻是否自然
- [ ] 測試 Conventional Commits 摺疊互動
- [ ] 檢視「5 分鐘開始」步驟樣式

🤖 Generated with [Claude Code](https://claude.com/claude-code)